### PR TITLE
(related to Issue #5) .size() to .length due to jQuery 3 size() removal.

### DIFF
--- a/ckanext/usmetadata/fanstatic/dataset_edit_form.js
+++ b/ckanext/usmetadata/fanstatic/dataset_edit_form.js
@@ -117,7 +117,7 @@ var DatasetForm = new function () {
 }();
 
 $().ready(function () {
-    if ($('form.dataset-form').size() && $(':input[name="pkg_name"]').size()) {
+    if ($('form.dataset-form').length && $(':input[name="pkg_name"]').length) {
         DatasetForm.bootstrap();
     }
 });

--- a/ckanext/usmetadata/fanstatic/redactions.js
+++ b/ckanext/usmetadata/fanstatic/redactions.js
@@ -239,7 +239,7 @@ var RedactionControl = new function () {
         var redacted;
         if ('undefined' !== typeof redacted_json_raw) {  //  dataset resource (or distribution) way
             redacted = redacted_json_raw;
-        } else if ($('#redacted_json').size()) {     // dataset way
+        } else if ($('#redacted_json').length) {     // dataset way
             var redactedJson = $('#redacted_json');
             redacted = $.parseJSON(redactedJson.val());
         }

--- a/ckanext/usmetadata/fanstatic/resource_form.js
+++ b/ckanext/usmetadata/fanstatic/resource_form.js
@@ -226,7 +226,7 @@ var DatasetResourceForm = new function () {
 
 $().ready(function () {
     //to be sure we are editing a resource
-    if ($('form.dataset-resource-form').size()) {
+    if ($('form.dataset-resource-form').length) {
 
         DatasetResourceForm.bootstrap();
     }

--- a/ckanext/usmetadata/plugin.py
+++ b/ckanext/usmetadata/plugin.py
@@ -565,7 +565,8 @@ class CommonCoreMetadataFormPlugin(p.SingletonPlugin, p.toolkit.DefaultDatasetFo
         return None
 
     @classmethod
-    def usmetadata_filter(cls, data=None, mask='~~'):
+    def usmetadata_filter(cls, data='', mask='~~'):
+        data = data or ''  # get rid of None
         for redact in re.findall(REDACTION_STROKE_REGEX, data):
             data = data.replace(redact, mask)
         data = data.replace('[[/REDACTED]]', mask)

--- a/ckanext/usmetadata/plugin.py
+++ b/ckanext/usmetadata/plugin.py
@@ -16,6 +16,7 @@ import ckan.logic as logic
 import ckan.model as model
 import ckan.plugins as p
 import db_utils
+
 from ckan.common import _, json, request, c, g, response, is_flask_request, config
 from ckan.lib.base import BaseController
 
@@ -565,7 +566,8 @@ class CommonCoreMetadataFormPlugin(p.SingletonPlugin, p.toolkit.DefaultDatasetFo
         return None
 
     @classmethod
-    def usmetadata_filter(cls, data=None, mask='~~'):
+    def usmetadata_filter(cls, data='', mask='~~'):
+        data = unicode(data)  # get rid of None, True, etc.
         for redact in re.findall(REDACTION_STROKE_REGEX, data):
             data = data.replace(redact, mask)
         data = data.replace('[[/REDACTED]]', mask)

--- a/ckanext/usmetadata/plugin.py
+++ b/ckanext/usmetadata/plugin.py
@@ -16,7 +16,6 @@ import ckan.logic as logic
 import ckan.model as model
 import ckan.plugins as p
 import db_utils
-
 from ckan.common import _, json, request, c, g, response, is_flask_request, config
 from ckan.lib.base import BaseController
 


### PR DESCRIPTION
Found while working on:
https://github.com/ViderumGlobal/PM-datagov/issues/5

The symptom was internal server error while working with datasets in a CKAN instance which uses the ckanext-datagovtheme extension.

See also:
https://stackoverflow.com/questions/40002951/typeerror-parents-size-is-not-a-function